### PR TITLE
feature/cloudbuildtips

### DIFF
--- a/CloudBuildsTips/cancelot.sh
+++ b/CloudBuildsTips/cancelot.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# https://github.com/siberex/cancelot
+#
+# To download the latest version (if you trust running random bash scripts from the internets!):
+# curl -L https://gist.github.com/siberex/bb0540b208019382d08732cc6dd59007/raw -o cancelot.sh && chmod +x cancelot.sh
+#
+# Provides automation for cancelling Cloud Builds
+# Use as a first step to cancel previous builds currently in progress or queued for the same branch name and trigger id.
+# Similar to: https://github.com/GoogleCloudPlatform/cloud-builders-community/tree/master/cancelot
+
+# Usage stand-alone (gcloud CLI must be installed and authorised):
+#    ./cancelot.sh --current_build_id $BUILD_ID --branch_name $BRANCH_NAME [--same_trigger_only] [--project "gcloud-project-id"] [--region ""]
+#
+# Could be configured with arguments or via ENV (or mixed).
+# Arguments will take priority.
+#
+# Usage within Cloud Build step:
+#    steps:
+#    - name: 'gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine'
+#      entrypoint: bash
+#      args:
+#        - cancelot.sh --same_trigger_only
+#      env:
+#        - 'CURRENT_BUILD_ID=$BUILD_ID'
+#        - 'PROJECT_ID=$PROJECT_ID'
+#        - 'REGION=$LOCATION'
+
+# Exit script when command fails
+set -o errexit
+# Return value of a pipeline is the value of the last (rightmost) command to exit with a non-zero status
+set -o pipefail
+
+# Note: GitHub App builds DOES NOT contain Source.RepoSource.Revision.BranchName field.
+# The actual source for GitHub repo will be storageSource.bucket, check actual source with:
+# $ gcloud builds describe $BUILD_ID --format=json
+
+# We still could use substitutions.BRANCH_NAME
+# https://cloud.google.com/build/docs/configuring-builds/substitute-variable-values
+
+CMDNAME=${0##*/}
+echoerr() { echo "$@" 1>&2; }
+
+usage() {
+    cat <<USAGE >&2
+Usage:
+    $CMDNAME --current_build_id \$BUILD_ID [--branch_name \$BRANCH_NAME] [--same_trigger_only] [--project "gcloud-project-id"] [--region "europe-west2"]
+    --current_build_id \$BUILD_ID  Current Build Id
+    --branch_name \$BRANCH_NAME    Trigger branch (aka head branch)
+                                    (optional, defaults to current build substitutions.BRANCH_NAME)
+    --project                      GCloud Project Id
+    --region                       GCloud Region, empty value
+    --same_trigger_only            Only cancel builds with the same Trigger Id as current build’s trigger id
+                                    (optional, defaults to false = cancel all matching branch)
+USAGE
+    exit 1
+}
+
+SAME_TRIGGER_ONLY=0
+
+# Process arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+    --current_build_id)
+        CURRENT_BUILD_ID="$2"
+        if [[ $CURRENT_BUILD_ID == "" ]]; then break; fi
+        shift 2
+        ;;
+    --branch_name)
+        TARGET_BRANCH="$2"
+        shift 2
+        ;;
+    --same_trigger_only)
+        SAME_TRIGGER_ONLY=1
+        shift 1
+        ;;
+    --project)
+        PROJECT_ID="$2"
+        shift 2
+        ;;
+    --region)
+        REGION="$2"
+        shift 2
+        ;;
+    --help)
+        usage
+        ;;
+    *)
+        echoerr "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if [[ "$CURRENT_BUILD_ID" == "" ]]; then
+    echo "Error: you need to provide Build Id"
+    usage
+fi
+
+# In case Project Id were not provided via ENV or ARG, get it from the auth config.
+# Could be useful to run cancelot locally or in CI environments other than Cloud Build.
+GOOGLE_CLOUD_PROJECT=${PROJECT_ID:-$(gcloud config list --format 'get(core.project)')}
+
+# Note: DO NOT guess Region from the Project. Region should be set explicitly (via ENV or ARG) or left empty.
+# For example, we could get region for App Engine project like this:
+#  gcloud app describe --project "$GOOGLE_CLOUD_PROJECT" --format 'get(locationId)'
+# But Cloud Builds for AppEngine are multi-regional, so the correct value for region will be empty "" or "(unset)"
+GOOGLE_CLOUD_REGION=${REGION:-"(unset)"}
+
+echo "Getting Cloud Builds for ProjectId=$GOOGLE_CLOUD_PROJECT with region filter: $GOOGLE_CLOUD_REGION"
+
+# Note BUILD_BRANCH and BUILD_TRIGGER_ID could be empty
+QUERY_BUILD=$(gcloud builds describe "$CURRENT_BUILD_ID" --project="$GOOGLE_CLOUD_PROJECT" --region="$GOOGLE_CLOUD_REGION" --format="csv[no-heading](createTime, buildTriggerId, substitutions.BRANCH_NAME)")
+IFS="," read -r BUILD_CREATE_TIME BUILD_TRIGGER_ID BUILD_BRANCH <<<"$QUERY_BUILD"
+
+FILTERS="id!=$CURRENT_BUILD_ID AND createTime<$BUILD_CREATE_TIME"
+
+if [[ -z $TARGET_BRANCH ]]; then
+    TARGET_BRANCH="$BUILD_BRANCH"
+fi
+if [[ -n $TARGET_BRANCH ]]; then
+    FILTERS="$FILTERS AND substitutions.BRANCH_NAME=$TARGET_BRANCH"
+fi
+
+if [[ $SAME_TRIGGER_ONLY -eq 1 ]]; then
+    # Get Trigger Id from current build
+    FILTERS="$FILTERS AND buildTriggerId=$BUILD_TRIGGER_ID"
+    echo "Filtering Trigger Id: $BUILD_TRIGGER_ID"
+fi
+
+echo "Filtering ongoing builds for branch '$TARGET_BRANCH' created before: $BUILD_CREATE_TIME"
+# echo "$FILTERS"
+
+# Get ongoing build ids to cancel (+status)
+while IFS=$'\n' read -r line; do CANCEL_BUILDS+=("$line"); done < <(gcloud builds list --ongoing --filter="$FILTERS" --project="$GOOGLE_CLOUD_PROJECT" --region="$GOOGLE_CLOUD_REGION" --format="value(id, status)")
+
+BUILDS_COUNT=${#CANCEL_BUILDS[@]}
+echo "Found $BUILDS_COUNT builds to cancel"
+if [[ $BUILDS_COUNT -eq 0 ]]; then
+    exit 0
+fi
+
+# Cancel builds one by one to get output for each
+# printf '%s\n' "${CANCEL_BUILDS[@]}"
+echo "BUILD ID                                CURRENT STATUS"
+for build in "${CANCEL_BUILDS[@]}"; do
+    echo "$build"
+    ID=$(echo "$build" | awk '{print $1;}')
+    gcloud builds cancel "$ID" --project="$GOOGLE_CLOUD_PROJECT" --region="$GOOGLE_CLOUD_REGION" >/dev/null || true
+done

--- a/CloudBuildsTips/cloud_build_lock_manager.sh
+++ b/CloudBuildsTips/cloud_build_lock_manager.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# set -euxo pipefail
+set -euo pipefail
+LOCKFILE_PATH="gs://${PROJECT_ID}_cloudbuild/$TRIGGER_NAME/"
+INTERVAL=${INTERVAL:-5}
+CREATE_TIME=$(gcloud builds describe "$CURRENT_BUILD_ID" --format="value(createTime)")
+CREATE_TIMESTAMP=$(date --date="$CREATE_TIME" +%s)
+
+# ロックファイルを作成する関数
+function create_lockfile {
+    date >"${CREATE_TIMESTAMP}_${CURRENT_BUILD_ID}.lock"
+    gcloud storage cp "${CREATE_TIMESTAMP}_${CURRENT_BUILD_ID}.lock" "${LOCKFILE_PATH}" || echo "ERROR creating lock file"
+    echo "Lock file ${CREATE_TIMESTAMP}_${CURRENT_BUILD_ID}.lock has been created"
+}
+# ロックファイルを削除する関数
+function delete_lockfile {
+    gcloud storage rm "${LOCKFILE_PATH}${CREATE_TIMESTAMP}_${CURRENT_BUILD_ID}.lock" || echo "ERROR removing lock file"
+    echo "Lock file ${CREATE_TIMESTAMP}_${CURRENT_BUILD_ID}.lock has been removed"
+}
+# 条件に合致するロックファイルの数をカウントする関数
+function lock_file_count {
+    mapfile -t lock_files < <(gcloud storage ls "$LOCKFILE_PATH" | xargs -I VAR basename VAR .lock)
+    local count=0
+    for lock_file in "${lock_files[@]}"; do
+        # tt = timestamp, bid = build id
+        IFS='_' read -r tt bid <<<"$lock_file"
+        # shellcheck disable=SC2053
+        if [[ $tt -le $CREATE_TIMESTAMP && $bid != $CURRENT_BUILD_ID ]]; then
+            ((count++))
+        fi
+    done
+    echo $count
+}
+# ロックファイルがあれば待機する関数
+function wait_build {
+    while
+        LOCK_COUNT=$(lock_file_count)
+        ((LOCK_COUNT >= 1))
+    do
+        echo "Current number of ongoing builds: $LOCK_COUNT. Please wait a moment... Interval: $INTERVAL seconds."
+        sleep "$INTERVAL"
+    done
+}
+# ビルドをキャンセルする関数
+function cancel_build {
+    mapfile -t lock_files < <(gcloud storage ls "$LOCKFILE_PATH" | xargs -I VAR basename VAR .lock)
+    for lock_file in "${lock_files[@]}"; do
+        # tt = timestamp, bid = build id
+        IFS='_' read -r tt bid <<<"$lock_file"
+        # shellcheck disable=SC2053
+        if [[ $tt -le $CREATE_TIMESTAMP && $bid != $CURRENT_BUILD_ID ]]; then
+            gcloud builds cancel "$bid" >/dev/null || echo "ERROR canceling build $bid"
+            echo "Build $bid has been canceled"
+            gcloud storage rm "${LOCKFILE_PATH}${lock_file}.lock" || echo "ERROR removing lock file"
+            echo "Lock file ${lock_file}.lock has been removed"
+        fi
+    done
+}
+
+# コマンドの引数に応じて関数を呼び出す
+case "$1" in
+post-process)
+    delete_lockfile
+    ;;
+wait-process)
+    create_lockfile
+    wait_build
+    ;;
+cancel-process)
+    create_lockfile
+    cancel_build
+    ;;
+*)
+    echo "Usage: $0 {post-process|wait-process|cancel-process}"
+    exit 1
+    ;;
+esac

--- a/CloudBuildsTips/cloudbuild.yaml
+++ b/CloudBuildsTips/cloudbuild.yaml
@@ -18,5 +18,3 @@ steps:
       echo "完了しました！"
     waitFor:
       - cancelot
-# options:
-#   logging: CLOUD_LOGGING_ONLY

--- a/CloudBuildsTips/cloudbuild.yaml
+++ b/CloudBuildsTips/cloudbuild.yaml
@@ -1,20 +1,20 @@
 steps:
-  - id: cancelot
+  - id: waiting
     name: 'gcr.io/cloud-builders/gcloud-slim'
     entrypoint: bash
-    args: ['CloudBuildsTips/cancelot.sh', '--same_trigger_only']
+    args: ['CloudBuildsTips/waiting.sh']
     env:
       - 'CURRENT_BUILD_ID=$BUILD_ID'
       - 'PROJECT_ID=$PROJECT_ID'
-  - id: 'wait-120-seconds'
+  - id: 'wait-30-seconds'
     name: 'bash'
     script: |
       #!/usr/bin/env bash
-      # 120秒間、毎秒カウントダウン
-      for i in {120..1}; do
+      # 30秒間、毎秒カウントダウン
+      for i in {30..1}; do
         echo "待機中... 残り${i}秒"
         sleep 1
       done
       echo "完了しました！"
     waitFor:
-      - cancelot
+      - waiting

--- a/CloudBuildsTips/cloudbuild.yaml
+++ b/CloudBuildsTips/cloudbuild.yaml
@@ -1,4 +1,7 @@
 steps:
+  - name: 'bash'
+    args:
+      - 'ls -alh'
   - id: cancelot
     name: 'gcr.io/cloud-builders/gcloud-slim'
     entrypoint: bash

--- a/CloudBuildsTips/cloudbuild.yaml
+++ b/CloudBuildsTips/cloudbuild.yaml
@@ -1,8 +1,6 @@
 steps:
-  - name: 'gcr.io/cloud-builders/gcloud-slim'
-    entrypoint: bash
+  - name: 'ubuntu:latest'
     args:
-      - '-c'
       - 'ls'
       - '-alh'
       - 'CloudBuildsTips'

--- a/CloudBuildsTips/cloudbuild.yaml
+++ b/CloudBuildsTips/cloudbuild.yaml
@@ -1,0 +1,11 @@
+steps:
+  - id: 'wait-120-seconds'
+    name: 'bash'
+    script: |
+      #!/usr/bin/env bash
+      # 120秒間、毎秒カウントダウン
+      for i in {120..1}; do
+        echo "待機中... 残り${i}秒"
+        sleep 1
+      done
+      echo "完了しました！"

--- a/CloudBuildsTips/cloudbuild.yaml
+++ b/CloudBuildsTips/cloudbuild.yaml
@@ -6,6 +6,7 @@ steps:
     env:
       - 'CURRENT_BUILD_ID=$BUILD_ID'
       - 'PROJECT_ID=$PROJECT_ID'
+      - 'INTERVAL=10'
   - id: 'wait-30-seconds'
     name: 'bash'
     script: |

--- a/CloudBuildsTips/cloudbuild.yaml
+++ b/CloudBuildsTips/cloudbuild.yaml
@@ -1,9 +1,4 @@
 steps:
-  - name: 'ubuntu:latest'
-    args:
-      - 'ls'
-      - '-alh'
-      - 'CloudBuildsTips'
   - id: cancelot
     name: 'gcr.io/cloud-builders/gcloud-slim'
     entrypoint: bash

--- a/CloudBuildsTips/cloudbuild.yaml
+++ b/CloudBuildsTips/cloudbuild.yaml
@@ -9,5 +9,6 @@ steps:
         sleep 1
       done
       echo "完了しました！"
-options:
-  logging: CLOUD_LOGGING_ONLY
+
+# options:
+#   logging: CLOUD_LOGGING_ONLY

--- a/CloudBuildsTips/cloudbuild.yaml
+++ b/CloudBuildsTips/cloudbuild.yaml
@@ -9,3 +9,5 @@ steps:
         sleep 1
       done
       echo "完了しました！"
+options:
+  logging: CLOUD_LOGGING_ONLY

--- a/CloudBuildsTips/cloudbuild.yaml
+++ b/CloudBuildsTips/cloudbuild.yaml
@@ -1,14 +1,12 @@
 steps:
   - id: cancelot
-    name: 'gcr.io/$PROJECT_ID/cancelot'
+    name: 'gcr.io/cloud-builders/gcloud-slim'
+    entrypoint: bash
     args:
-      [
-        '--current_build_id',
-        '$BUILD_ID',
-        '--branch_name',
-        '$BRANCH_NAME',
-        '--same_trigger_only',
-      ]
+      - CloudBuldsTips/cancelot.sh --same_trigger_only
+    env:
+      - 'CURRENT_BUILD_ID=$BUILD_ID'
+      - 'PROJECT_ID=$PROJECT_ID'
   - id: 'wait-120-seconds'
     name: 'bash'
     script: |

--- a/CloudBuildsTips/cloudbuild.yaml
+++ b/CloudBuildsTips/cloudbuild.yaml
@@ -2,7 +2,9 @@ steps:
   - name: 'gcr.io/cloud-builders/gcloud-slim'
     entrypoint: bash
     args:
-      - 'ls -alh'
+      - '-c'
+      - 'ls'
+      - '-alh'
   - id: cancelot
     name: 'gcr.io/cloud-builders/gcloud-slim'
     entrypoint: bash

--- a/CloudBuildsTips/cloudbuild.yaml
+++ b/CloudBuildsTips/cloudbuild.yaml
@@ -1,5 +1,6 @@
 steps:
-  - name: 'bash'
+  - name: 'gcr.io/cloud-builders/gcloud-slim'
+    entrypoint: bash
     args:
       - 'ls -alh'
   - id: cancelot

--- a/CloudBuildsTips/cloudbuild.yaml
+++ b/CloudBuildsTips/cloudbuild.yaml
@@ -3,7 +3,7 @@ steps:
     name: 'gcr.io/cloud-builders/gcloud-slim'
     entrypoint: bash
     args:
-      - CloudBuldsTips/cancelot.sh --same_trigger_only
+      - CloudBuildsTips/cancelot.sh --same_trigger_only
     env:
       - 'CURRENT_BUILD_ID=$BUILD_ID'
       - 'PROJECT_ID=$PROJECT_ID'

--- a/CloudBuildsTips/cloudbuild.yaml
+++ b/CloudBuildsTips/cloudbuild.yaml
@@ -1,4 +1,14 @@
 steps:
+  - id: cancelot
+    name: 'gcr.io/$PROJECT_ID/cancelot'
+    args:
+      [
+        '--current_build_id',
+        '$BUILD_ID',
+        '--branch_name',
+        '$BRANCH_NAME',
+        '--same_trigger_only',
+      ]
   - id: 'wait-120-seconds'
     name: 'bash'
     script: |
@@ -9,6 +19,7 @@ steps:
         sleep 1
       done
       echo "完了しました！"
-
+    waitFor:
+      - cancelot
 # options:
 #   logging: CLOUD_LOGGING_ONLY

--- a/CloudBuildsTips/cloudbuild.yaml
+++ b/CloudBuildsTips/cloudbuild.yaml
@@ -2,8 +2,7 @@ steps:
   - id: cancelot
     name: 'gcr.io/cloud-builders/gcloud-slim'
     entrypoint: bash
-    args:
-      - CloudBuildsTips/cancelot.sh --same_trigger_only
+    args: ['CloudBuildsTips/cancelot.sh', '--same_trigger_only']
     env:
       - 'CURRENT_BUILD_ID=$BUILD_ID'
       - 'PROJECT_ID=$PROJECT_ID'

--- a/CloudBuildsTips/cloudbuild.yaml
+++ b/CloudBuildsTips/cloudbuild.yaml
@@ -5,6 +5,7 @@ steps:
       - '-c'
       - 'ls'
       - '-alh'
+      - 'CloudBuildsTips'
   - id: cancelot
     name: 'gcr.io/cloud-builders/gcloud-slim'
     entrypoint: bash

--- a/CloudBuildsTips/cloudbuild_submit_cancel.yaml
+++ b/CloudBuildsTips/cloudbuild_submit_cancel.yaml
@@ -1,0 +1,36 @@
+steps:
+  - id: cancel
+    name: 'gcr.io/cloud-builders/gcloud-slim'
+    entrypoint: bash
+    args: ['cloud_build_lock_manager.sh', 'cancel-process']
+    env:
+      - 'CURRENT_BUILD_ID=$BUILD_ID'
+      - 'PROJECT_ID=$PROJECT_ID'
+      - 'INTERVAL=$_INTERVAL'
+      - 'TRIGGER_NAME=$_TRIGGER_NAME'
+  - id: 'wait-30-seconds'
+    name: 'bash'
+    script: |
+      #!/usr/bin/env bash
+      # 30秒間、毎秒カウントダウン
+      for i in {30..1}; do
+        echo "待機中... 残り${i}秒"
+        sleep 1
+      done
+      echo "完了しました！"
+    waitFor:
+      - cancel
+  - id: 'post-process'
+    name: 'gcr.io/cloud-builders/gcloud-slim'
+    entrypoint: bash
+    args: ['cloud_build_lock_manager.sh', 'post-process']
+    env:
+      - 'CURRENT_BUILD_ID=$BUILD_ID'
+      - 'PROJECT_ID=$PROJECT_ID'
+      - 'INTERVAL=$_INTERVAL'
+      - 'TRIGGER_NAME=$_TRIGGER_NAME'
+    waitFor:
+      - 'wait-30-seconds'
+substitutions:
+  _INTERVAL: '10'
+  _TRIGGER_NAME: wait-30-seconds

--- a/CloudBuildsTips/cloudbuild_submit_waiting.yaml
+++ b/CloudBuildsTips/cloudbuild_submit_waiting.yaml
@@ -1,0 +1,36 @@
+steps:
+  - id: waiting
+    name: 'gcr.io/cloud-builders/gcloud-slim'
+    entrypoint: bash
+    args: ['cloud_build_lock_manager.sh', 'wait-process']
+    env:
+      - 'CURRENT_BUILD_ID=$BUILD_ID'
+      - 'PROJECT_ID=$PROJECT_ID'
+      - 'INTERVAL=$_INTERVAL'
+      - 'TRIGGER_NAME=$_TRIGGER_NAME'
+  - id: 'wait-30-seconds'
+    name: 'bash'
+    script: |
+      #!/usr/bin/env bash
+      # 30秒間、毎秒カウントダウン
+      for i in {30..1}; do
+        echo "待機中... 残り${i}秒"
+        sleep 1
+      done
+      echo "完了しました！"
+    waitFor:
+      - waiting
+  - id: 'post-process'
+    name: 'gcr.io/cloud-builders/gcloud-slim'
+    entrypoint: bash
+    args: ['cloud_build_lock_manager.sh', 'post-process']
+    env:
+      - 'CURRENT_BUILD_ID=$BUILD_ID'
+      - 'PROJECT_ID=$PROJECT_ID'
+      - 'INTERVAL=$_INTERVAL'
+      - 'TRIGGER_NAME=$_TRIGGER_NAME'
+    waitFor:
+      - 'wait-30-seconds'
+substitutions:
+  _INTERVAL: '10'
+  _TRIGGER_NAME: wait-30-seconds

--- a/CloudBuildsTips/waiting.sh
+++ b/CloudBuildsTips/waiting.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-set -eux
+# set -euxo pipefail
+set -euo pipefail
 
 GOOGLE_CLOUD_PROJECT=${PROJECT_ID:-$(gcloud config list --format 'get(core.project)')}
 QUERY_BUILD=$(gcloud builds describe "$CURRENT_BUILD_ID" --project="$GOOGLE_CLOUD_PROJECT" --format="csv[no-heading](createTime, buildTriggerId)")

--- a/CloudBuildsTips/waiting.sh
+++ b/CloudBuildsTips/waiting.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -eux
+
+GOOGLE_CLOUD_PROJECT=${PROJECT_ID:-$(gcloud config list --format 'get(core.project)')}
+QUERY_BUILD=$(gcloud builds describe "$CURRENT_BUILD_ID" --project="$GOOGLE_CLOUD_PROJECT" --format="csv[no-heading](createTime, buildTriggerId)")
+IFS="," read -r BUILD_CREATE_TIME BUILD_TRIGGER_ID <<<"$QUERY_BUILD"
+
+FILTERS="id!=$CURRENT_BUILD_ID AND createTime<$BUILD_CREATE_TIME AND buildTriggerId=$BUILD_TRIGGER_ID"
+echo "Waiting for all builds to finish $FILTERS"
+while
+  BUILDS_COUNT=$(gcloud builds list --ongoing --filter="$FILTERS" --format="value(id)" | wc -l)
+  (( BUILDS_COUNT < 1 ))
+do
+  echo "Current number of ongoing builds: $BUILDS_COUNT. Please wait a moment..."
+  sleep 5
+done

--- a/CloudBuildsTips/waiting.sh
+++ b/CloudBuildsTips/waiting.sh
@@ -8,11 +8,11 @@ IFS="," read -r BUILD_CREATE_TIME BUILD_TRIGGER_ID <<<"$QUERY_BUILD"
 
 FILTERS="id!=$CURRENT_BUILD_ID AND createTime<$BUILD_CREATE_TIME AND buildTriggerId=$BUILD_TRIGGER_ID"
 echo "Waiting for all builds to finish $FILTERS"
-INTERVALS=${INTERVALS:-5}
+INTERVAL=${INTERVAL:-5}
 while
   BUILDS_COUNT=$(gcloud builds list --ongoing --filter="$FILTERS" --format="value(id)" | wc -l)
   (( BUILDS_COUNT >= 1 ))
 do
-  echo "Current number of ongoing builds: $BUILDS_COUNT. Please wait a moment... Interval: $INTERVALS seconds."
-  sleep $INTERVALS
+  echo "Current number of ongoing builds: $BUILDS_COUNT. Please wait a moment... Interval: $INTERVAL seconds."
+  sleep $INTERVAL
 done

--- a/CloudBuildsTips/waiting.sh
+++ b/CloudBuildsTips/waiting.sh
@@ -8,10 +8,11 @@ IFS="," read -r BUILD_CREATE_TIME BUILD_TRIGGER_ID <<<"$QUERY_BUILD"
 
 FILTERS="id!=$CURRENT_BUILD_ID AND createTime<$BUILD_CREATE_TIME AND buildTriggerId=$BUILD_TRIGGER_ID"
 echo "Waiting for all builds to finish $FILTERS"
+INTERVALS=${INTERVALS:-5}
 while
   BUILDS_COUNT=$(gcloud builds list --ongoing --filter="$FILTERS" --format="value(id)" | wc -l)
   (( BUILDS_COUNT >= 1 ))
 do
-  echo "Current number of ongoing builds: $BUILDS_COUNT. Please wait a moment..."
-  sleep 5
+  echo "Current number of ongoing builds: $BUILDS_COUNT. Please wait a moment... Interval: $INTERVALS seconds."
+  sleep $INTERVALS
 done

--- a/CloudBuildsTips/waiting.sh
+++ b/CloudBuildsTips/waiting.sh
@@ -9,7 +9,7 @@ FILTERS="id!=$CURRENT_BUILD_ID AND createTime<$BUILD_CREATE_TIME AND buildTrigge
 echo "Waiting for all builds to finish $FILTERS"
 while
   BUILDS_COUNT=$(gcloud builds list --ongoing --filter="$FILTERS" --format="value(id)" | wc -l)
-  (( BUILDS_COUNT < 1 ))
+  (( BUILDS_COUNT >= 1 ))
 do
   echo "Current number of ongoing builds: $BUILDS_COUNT. Please wait a moment..."
   sleep 5


### PR DESCRIPTION
- Add cloudbuild.yaml file for Cloud Builds tips
- Add logging option to cloudbuild.yaml
- Remove logging option from cloudbuild.yaml
- add cancelot
- Update cloudbuild.yaml to use gcr.io/cloud-builders/gcloud-slim and pass necessary arguments
- fix
- update to array
- test
- test
- test
- test
- test
- Add cancelot.sh script for automating cancellation of Cloud Builds
- Remove unnecessary step in cloudbuild.yaml
- Update cancelot.sh and cloudbuild.yaml
- add: waiting
- add: waiting
- Update build count condition in waiting.sh script
- Update waiting.sh script to include pipefail option
- Update waiting.sh script to include customizable interval for build checks
- Add INTERVAL variable to cloudbuild.yaml and waiting.sh
- Add cloud_build_lock_manager.sh script and cloudbuild_submit_cancel.yaml and cloudbuild_submit_waiting.yaml files
